### PR TITLE
Fixed spelling for configuration_groups index.erb label

### DIFF
--- a/views/configuration_groups/index.erb
+++ b/views/configuration_groups/index.erb
@@ -37,7 +37,7 @@
 <div class="container">
   <form  method="post">
     <label>Add new Configuration Group</label>
-    <input class="form-control" type="text" name="name" id="group" placeholder="New Connfiguration Group">
+    <input class="form-control" type="text" name="name" id="group" placeholder="New Configuration Group">
     <button type="submit" class="btn btn-default">Submit</button>
   </form>
 </div>


### PR DESCRIPTION
Just set this up and noticed the spelling error, thought it'd make sense to fix it. Mostly just an excuse for me to learn how to do a PR properly..