### PR TITLE
Adds list of endpoints to the configuration edit page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'omniauth-google-oauth2'
 gem 'encrypted_cookie'
 gem 'time_difference'
 gem 'will_paginate'
+gem 'dotenv'
 
 group :test, :development do
   gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
       xpath (~> 2.0)
     database_cleaner (1.4.1)
     diff-lcs (1.2.5)
+    dotenv (2.0.2)
     encrypted_cookie (0.0.4)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
@@ -119,6 +120,7 @@ DEPENDENCIES
   activerecord
   capybara
   database_cleaner
+  dotenv
   encrypted_cookie
   json
   omniauth

--- a/server.rb
+++ b/server.rb
@@ -1,3 +1,5 @@
+require 'dotenv'
+Dotenv.load
 require 'sinatra'
 require 'sinatra/namespace'
 require 'sinatra/flash'
@@ -285,7 +287,9 @@ namespace '/configuration-groups' do
       end
 
       get '/:config_id/edit' do
-        @config = GuaranteedConfiguration.find(params[:config_id])
+        @config = Configuration.find(params[:config_id])
+        @endpoints = @config.assigned_endpoints.order('last_config_time is NULL, last_config_time DESC').page(params[:page])
+
         erb :"configurations/edit"
       end
 

--- a/views/configurations/edit.erb
+++ b/views/configurations/edit.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <h2>Editing configuration in "<%= @config.configuration_group.name  %>" Configuration Group</h2>
   <form action="<%= "/configuration-groups/#{@config.configuration_group.id}/configurations/#{@config.id}" %>" method="POST">
     <div class="form-group">
       <label>Name</label>
@@ -29,4 +30,30 @@
     <% end %>
     <button type="submit" class="btn btn-default">Update</button>
   </form>
+
+  <h2>Endpoints with this configuration (<%= @endpoints.count %>)</h2>
+  <%= will_paginate @endpoints %>
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Identifier</th>
+        <th>Osquery version</th>
+        <th>Config refresh count</th>
+        <th>Last ip address</th>
+        <th>Last config refresh</th>
+        <th>Running Configuration</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @endpoints.each do |endpoint| %>
+        <tr>
+          <td><%= endpoint.identifier %></td>
+          <td><%= endpoint.last_version %></td>
+          <td><%= endpoint.config_count %></td>
+          <td><%= endpoint.last_ip %></td>
+          <td><%= endpoint.last_config_time %> (<%= difftime(endpoint.last_config_time, DateTime.now) %>)</td>
+          <td><%= endpoint.last_config.name %></td>
+      <% end %>
+    </tbody>
+  </table>
 </div>


### PR DESCRIPTION
This should make @lexelby extra happy. This makes it so that when you view a configuration you can also see all the endpoints that have that config assigned. That way you don't have to page through all the endpoints in a ConfigurationGroup looking for the ones that have your canary assigned.