### PR TITLE
fix off-by-one in canary creation

### DIFF
--- a/lib/models/configuration_group.rb
+++ b/lib/models/configuration_group.rb
@@ -93,7 +93,7 @@ class ConfigurationGroup < ActiveRecord::Base
     remaining = self.endpoints.where.not(assigned_config: config).shuffle
 
     # now get the front of the whole list and assign configurations
-    remaining[0..number_todo].each do |e|
+    remaining[0,number_todo].each do |e|
       e.assigned_config = config
       e.save
     end


### PR DESCRIPTION
Oh ruby, your complicated array slicing is... complicated.  array[0..3] picks array indices 0 through 3 inclusive.  array[0,3] starts at 0 and picks 3 items.

This fixes #57.