### PR TITLE
add endpoint-cleanup and console utilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem 'encrypted_cookie'
 gem 'time_difference'
 gem 'will_paginate'
 gem 'dotenv'
+gem 'highline'
+gem 'squeel'
 
 group :test, :development do
   gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     hashie (3.4.2)
+    highline (1.7.8)
     i18n (0.7.0)
     json (1.8.1)
     jwt (1.5.1)
@@ -67,6 +68,8 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     pg (0.18.2)
+    polyamorous (1.1.0)
+      activerecord (>= 3.0)
     puma (2.12.3)
     rack (1.6.4)
     rack-protection (1.5.3)
@@ -103,6 +106,10 @@ GEM
     sinatra-flash (0.3.0)
       sinatra (>= 1.0.0)
     sqlite3 (1.3.10)
+    squeel (1.2.3)
+      activerecord (>= 3.0)
+      activesupport (>= 3.0)
+      polyamorous (~> 1.1.0)
     thread_safe (0.3.5)
     tilt (2.0.1)
     time_difference (0.4.2)
@@ -122,6 +129,7 @@ DEPENDENCIES
   database_cleaner
   dotenv
   encrypted_cookie
+  highline
   json
   omniauth
   omniauth-github
@@ -136,8 +144,6 @@ DEPENDENCIES
   sinatra-contrib
   sinatra-flash
   sqlite3
+  squeel
   time_difference
   will_paginate
-
-BUNDLED WITH
-   1.10.6

--- a/README.md
+++ b/README.md
@@ -217,3 +217,27 @@ adding a file `views/additiona_css.erb` and `views/additonal_js.erb`. These are
 embedded ruby file which are rendered in the main layout. The stylesheet partial
 is rendered in the head of the html and the javascript is rendered after the
 closing body tag.
+
+## Command-line utilities
+Windmill comes with two command-line utilities: `console` and `endpoint-cleanup`.
+
+### console
+The `console` utility gives you a simple IRB shell that you can use to examine and manipulate the Windmill database.  Take care here, because nothing will prevent you from deploying an osquery configuration without a proper canary test!
+
+Run the `console` utility like this:
+
+```
+heroku run bundle exec bin/console
+```
+
+### endpoint-cleanup
+The `endpoint-cleanup` utility deletes endpoints that have not polled for their configuration recently.  This can be useful if hosts in your infrastructure frequently come and go.  It is not strictly necessary to delete old endpoints, but doing so can make the Windmill UI easier to manage.
+
+Run the `endpoint-cleanup` utility like this:
+```
+heroku run bundle exec bin/endpoint-cleanup --help
+```
+
+With no arguments, this utility will **automatically** purge all endpoints that have not checked in within the past day, without confirmation.  The `-i` option prompts you for confirmation and allows you to view a list of endpoints that will be deleted.
+
+If desired, this utility is designed to be run in non-interactive mode using Heroku Scheduler or a similar scheduling add-on.

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require "irb"
+require "irb/completion"
+
+require_relative '../server'
+
+IRB.start

--- a/bin/endpoint-cleanup
+++ b/bin/endpoint-cleanup
@@ -1,0 +1,66 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'highline/import'
+
+require_relative '../server'
+require 'squeel'
+
+
+interactive = false
+max_age = 86400
+
+OptionParser.new do |opts|
+    opts.banner = "Usage: endpoint-cleanup [options]"
+
+    opts.on("-i", "--interactive", "Prompt for confirmation before removing endpoints.") do
+        interactive = true
+    end
+
+    opts.on("-m", "--max-age [SECONDS]", "Remove endpoints that last checked in more than this many seconds ago.") do |seconds|
+        max_age = seconds.to_i
+    end
+end.parse!
+
+puts "#{interactive ? 'interactively ' : ''}cleaning nodes older than #{max_age} seconds..."
+
+@stale = Endpoint.where{last_config_time < max_age.seconds.ago}
+num = @stale.length
+
+puts "found #{num} stale endpoints"
+
+if interactive
+    STDOUT.flush
+    STDOUT.sync = true
+
+    done = false
+    while not done do
+        puts
+        choose do |menu|
+            menu.prompt = "Do you want to delete #{num} endpoints?"
+            menu.choice :yes do
+                done = true
+            end
+            menu.choice :no do
+                exit
+            end
+            menu.choice "list endpoints" do 
+                begin
+                    IO.popen("less -F", "w") do |less|
+                        @stale.sort.each do |endpoint|
+                            less.puts(endpoint.identifier)
+                        end
+                    end
+                rescue Errno::EPIPE
+                end
+            end
+        end
+    end
+end
+
+
+puts "deleting #{num} stale endpoints"
+
+@stale.each do |e|
+    e.destroy
+end


### PR DESCRIPTION
Fixes #62, with a bonus of a `bin/console` utility.  The endpoint-cleanup utility supports batch mode for use in Scheduler and interactive mode for human use.  Currently available for testing on dev.