### PR TITLE
Use Release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma --config puma.rb config.ru
+release: rake db:migrate

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# osquery-tls-server
+# Windmill
 
 ## Why do you want this
 

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "Windmill",
   "description": "A TLS server for delivering config files to osquery endpoints",
-  "repository": "https://github.com/blackfist/windmill",
+  "repository": "https://github.com/heroku/windmill",
   "keywords": ["osquery", "tls", "sinatra", "ruby"],
   "env": {
     "AUTHORIZEDUSERS": {

--- a/app.json
+++ b/app.json
@@ -3,9 +3,6 @@
   "description": "A TLS server for delivering config files to osquery endpoints",
   "repository": "https://github.com/blackfist/windmill",
   "keywords": ["osquery", "tls", "sinatra", "ruby"],
-  "scripts": {
-    "postdeploy": "bundle exec rake db:setup"
-  },
   "env": {
     "AUTHORIZEDUSERS": {
       "description": "A comma seperated (no spaces) list of email addresses to allow access to",


### PR DESCRIPTION
This PR uses release commands to run `db:migrate` rather than a postdeploy script.